### PR TITLE
Update stylelint-order version to enable autofix

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "scripts": {},
   "devDependencies": {},
   "dependencies": {
-    "stylelint-order": "^0.4.3"
+    "stylelint-order": "^0.5.0"
   }
 }


### PR DESCRIPTION
Hi! Thank you for your plugin. I wanted to use an updated version to be able to autofix order with "stylelint --fix", but it's supported only in version 0.5.0: https://github.com/hudochenkov/stylelint-order/releases/tag/0.5.0, so here's a PR :)