### PR TITLE
:sparkles: Add prefixed font-smooth properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,8 @@ module.exports = {
       "font-emphasize",
       "font-emphasize-position",
       "font-emphasize-style",
+      "-webkit-font-smoothing",
+      "-moz-osx-font-smoothing",
       "font-smooth",
       "-webkit-hyphens",
       "-moz-hyphens",


### PR DESCRIPTION
Hi! I've noticed, that you have property font-smooth, but not it's prefixed variants, so I added them. See http://caniuse.com/#feat=font-smooth