### PR TITLE
Update stylelint-order dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "stylelint-order": "^0.7.0"
+    "stylelint-order": "^0.8.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.3",


### PR DESCRIPTION
Without this fix I am getting the warning:

```
warning "stylelint-config-recess-order > stylelint-order@0.7.0" has incorrect peer dependency "stylelint@^8.0.0".
```

because I use Stylelint 8.0.

@stormwarning thanks, your order is my favorite one.