### PR TITLE
🎁 Add unprefixed `gap` properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,7 @@ module.exports = {
             },
             {
                 // Display mode.
-                properties: [
-                    'box-sizing',
-                    'display',
-                ],
+                properties: ['box-sizing', 'display'],
             },
             {
                 // Flexible boxes.
@@ -58,6 +55,10 @@ module.exports = {
                     'grid-row-gap',
                     'grid-column-gap',
                 ],
+            },
+            {
+                // Gap.
+                properties: ['gap', 'row-gap', 'column-gap'],
             },
             {
                 // Align.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,7 +4549,7 @@
     },
     "fs-access": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-2.0.0.tgz",
       "integrity": "sha512-Vt45hBKJrYDQeAD9ja43liw8JfK75uB7XexIXWEtDKwFLQNmzmvuulh28hRxexxuFm0zsGGq7nISGQSK6KnGrA==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,71 +1,77 @@
 {
-  "name": "stylelint-config-recess-order",
-  "version": "2.0.4",
-  "description": "Recess-based property sort order for Stylelint.",
-  "keywords": [
-    "bootstrap",
-    "properties-order",
-    "property order",
-    "recess",
-    "stylelint",
-    "stylelint-config",
-    "stylelint-order"
-  ],
-  "homepage": "https://github.com/stormwarning/stylelint-config-recess-order",
-  "bugs": "https://github.com/stormwarning/stylelint-config-recess-order/issues",
-  "repository": "stormwarning/stylelint-config-recess-order",
-  "license": "ISC",
-  "author": "Jeff Nelson <rustyangel@gmail.com> (http://tidaltheory.co/)",
-  "main": "index.js",
-  "scripts": {
-    "lint": "eslint '**/*.js'",
-    "semantic-release": "semantic-release",
-    "test": "ava"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
+    "name": "stylelint-config-recess-order",
+    "version": "2.0.4",
+    "description": "Recess-based property sort order for Stylelint.",
+    "keywords": [
+        "bootstrap",
+        "properties-order",
+        "property order",
+        "recess",
+        "stylelint",
+        "stylelint-config",
+        "stylelint-order"
     ],
-    "package.json": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "ava": {
-    "require": [
-      "esm"
-    ]
-  },
-  "dependencies": {
-    "stylelint-order": "4.1.x"
-  },
-  "devDependencies": {
-    "@zazen/eslint-config": "2.0.x",
-    "@zazen/semantic-release": "0.1.3",
-    "ava": "3.9.x",
-    "eslint": "6.8.x",
-    "esm": "3.2.25",
-    "husky": "4.2.x",
-    "lint-staged": "10.2.x",
-    "prettier": "2.0.x",
-    "prettier-plugin-packagejson": "2.2.x",
-    "semantic-release": "17.1.x",
-    "stylelint": "13.6.x"
-  },
-  "peerDependencies": {
-    "stylelint": ">=9"
-  },
-  "release": {
-    "extends": "@zazen/semantic-release",
-    "branches": [
-      "master",
-      "next"
-    ]
-  }
+    "homepage": "https://github.com/stormwarning/stylelint-config-recess-order",
+    "bugs": "https://github.com/stormwarning/stylelint-config-recess-order/issues",
+    "repository": "stormwarning/stylelint-config-recess-order",
+    "license": "ISC",
+    "author": "Jeff Nelson <rustyangel@gmail.com> (http://tidaltheory.co/)",
+    "main": "index.js",
+    "scripts": {
+        "lint": "eslint '**/*.js'",
+        "semantic-release": "semantic-release",
+        "test": "ava"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "*.js": [
+            "eslint --fix",
+            "git add"
+        ],
+        "package.json": [
+            "prettier --write",
+            "git add"
+        ]
+    },
+    "prettier": {
+        "semi": false,
+        "singleQuote": true,
+        "tabWidth": 4,
+        "trailingComma": "all"
+    },
+    "ava": {
+        "require": [
+            "esm"
+        ]
+    },
+    "dependencies": {
+        "stylelint-order": "4.1.x"
+    },
+    "devDependencies": {
+        "@zazen/eslint-config": "2.0.x",
+        "@zazen/semantic-release": "0.1.3",
+        "ava": "3.9.x",
+        "eslint": "6.8.x",
+        "esm": "3.2.25",
+        "husky": "4.2.x",
+        "lint-staged": "10.2.x",
+        "prettier": "2.0.x",
+        "prettier-plugin-packagejson": "2.2.x",
+        "semantic-release": "17.1.x",
+        "stylelint": "13.6.x"
+    },
+    "peerDependencies": {
+        "stylelint": ">=9"
+    },
+    "release": {
+        "extends": "@zazen/semantic-release",
+        "branches": [
+            "master",
+            "next"
+        ]
+    }
 }


### PR DESCRIPTION
These are added outside of the other `grid` properties, since it is
now used in `flex` contexts as well, but directly after `grid-gap`
for better backwards-compatibility.

See [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
for refrence.

Closes #140