### PR TITLE
🎁 Add `place-items` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,10 @@ module.exports = {
                 ],
             },
             {
+                // Align + Justify.
+                properties: ['place-items'],
+            },
+            {
                 // Order.
                 properties: ['order'],
             },

--- a/index.js
+++ b/index.js
@@ -61,20 +61,16 @@ module.exports = {
                 properties: ['gap', 'row-gap', 'column-gap'],
             },
             {
-                // Align.
-                properties: ['align-content', 'align-items', 'align-self'],
-            },
-            {
-                // Justify.
+                // Layout alignment.
                 properties: [
-                    'justify-content',
-                    'justify-items',
-                    'justify-self',
+                  'place-items',
+                  'align-content',
+                  'align-items',
+                  'align-self',
+                  'justify-content',
+                  'justify-items',
+                  'justify-self',
                 ],
-            },
-            {
-                // Align + Justify.
-                properties: ['place-items'],
             },
             {
                 // Order.


### PR DESCRIPTION
From [CSS-Tricks](https://css-tricks.com/almanac/properties/p/place-items/):
> The `place-items` property in CSS is shorthand for the `align-items` and `justify-items` properties, combining them into a single declaration.