### PR TITLE
Add groups to package.json exports

### DIFF
--- a/.changeset/angry-clocks-perform.md
+++ b/.changeset/angry-clocks-perform.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recess-order": patch
+---
+
+Add `groups` to package.json exports

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "5.0.0",
   "description": "Recess-based property sort order for Stylelint.",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./groups": "./groups.js"
+  },
   "keywords": [
     "bootstrap",
     "properties-order",


### PR DESCRIPTION
Fix bug that prevents exporting `propertyGroups`

Upgrading from `v4.6.0` to `v5.0.0`

- Changed `.stylelintrc.js` to `.stylelintrc.mjs`

**From:**
```js
const propertyGroups = require("stylelint-config-recess-order/groups");

module.exports = {
```
**To:**
```js
import propertyGroups from "stylelint-config-recess-order/groups";

export default {
```


Error:


```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './groups' is not defined by "exports" in /home/user/Code/app/node_modules/stylelint-config-recess-order/package.json imported from /home/user/Code/app/.stylelintrc.mjs
```


### Solution

```
  "exports": {
    ".": "./index.js",
    "./groups": "./groups.js"
  },
```