### PR TITLE
Add Anchor Positioning properties

### DIFF
--- a/.changeset/real-readers-show.md
+++ b/.changeset/real-readers-show.md
@@ -1,0 +1,15 @@
+---
+'stylelint-config-recess-order': minor
+---
+
+Add Anchor Positioning properties
+
+- [`anchor-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/anchor-name)
+- [`anchor-scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/anchor-scope)
+- `anchor-center`
+- [`position-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-area)
+- [`position-anchor`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-anchor)
+- [`position-try`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-try)
+- [`position-try-order`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-try-order)
+- [`position-try-fallbacks`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-fallbacks)
+- [`position-visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-visibility)

--- a/groups.js
+++ b/groups.js
@@ -188,6 +188,19 @@ const propertyGroups = [
 	 * Anchor positioning.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning#reference
 	 */
+	{
+		properties: [
+			'anchor-name',
+			'anchor-scope',
+			'anchor-center',
+			'position-area',
+			'position-anchor',
+			'position-try',
+			'position-try-order',
+			'position-try-fallbacks',
+			'position-visibility',
+		],
+	},
 
 	/**
 	 * Containment.


### PR DESCRIPTION
-
  [`anchor-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/anchor-name)
-
  [`anchor-scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/anchor-scope)
- `anchor-center`
-
  [`position-area`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-area)
-
  [`position-anchor`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-anchor)
-
  [`position-try`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-try)
-
  [`position-try-order`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-try-order)
-
  [`position-try-fallbacks`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-fallbacks)
-
  [`position-visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-visibility)
