### PR TITLE
Allow stylelint-order v8 as peer dependency

### DIFF
--- a/.changeset/eighty-snails-fix.md
+++ b/.changeset/eighty-snails-fix.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recess-order": minor
+---
+
+Allow [stylelint-order v8](https://github.com/hudochenkov/stylelint-order/releases/tag/8.0.0) as peer dependency

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
 		"lint-staged": "16.2.7",
 		"prettier": "3.8.1",
 		"stylelint": "17.2.0",
-		"stylelint-order": "7.0.1"
+		"stylelint-order": "8.0.0"
 	},
 	"peerDependencies": {
 		"stylelint": "^16.18.0 || ^17.0.0",
-		"stylelint-order": "^7.0.0"
+		"stylelint-order": "^7.0.0 || ^8.0.0"
 	},
 	"pnpm": {
 		"overrides": {}


### PR DESCRIPTION
See https://github.com/hudochenkov/stylelint-order/releases/tag/8.0.0